### PR TITLE
Добавить вызов стандартной функции pinMode() в отношении каждого пина в теле метода disable()

### DIFF
--- a/src/RGBLED.h
+++ b/src/RGBLED.h
@@ -35,6 +35,9 @@ class RGBLED : public RGB {
 
     // выкл
     void disable() {
+        pinMode(_rpin, OUTPUT);
+        pinMode(_gpin, OUTPUT);
+        pinMode(_bpin, OUTPUT);
         digitalWrite(_rpin, _anode);
         digitalWrite(_gpin, _anode);
         digitalWrite(_bpin, _anode);


### PR DESCRIPTION
При использовании вашей библиотеки с аппаратной платформой ESP32 в рамках фреймворка Arduino столкнулся с тем, что вызов метода disable() не приводил к требуемым результатам: светодиоды оставались включёнными.

Опытным путём выяснил, что добавление вызова стандартной функции pinMode() (с макросом OUTPUT в качестве второго параметра) в отношении каждого пина в теле метода disable() устраняет упомянутую проблему.

Корректность работы метода enable() с учётом предлагаемого мной апдейта кода я проверил, функциональность подтверждена.

Стоит отметить, что первоначально я добавил вызовы pinMode() не в тело метода disable(), а в конструктор класса RGBLED (это казалось логичным). Однако по не до конца понятной мне причине это приводило к последующей невозможности выключить светодиоды с помощью метода disable(). Вероятно, дело в чём-то связанном с очерёдностью установки режимов работы пинов. Поэтому я пришёл к добавлению вызовов pinMode() в disable(), а не в конструктор.