### PR TITLE
Remove the pinMode() calls from the RGBLED class constructor.

### DIFF
--- a/src/RGBLED.h
+++ b/src/RGBLED.h
@@ -9,9 +9,6 @@ class RGBLED : public RGB {
     static const bool COM_CATHODE = false;
 
     RGBLED(uint8_t rpin, uint8_t gpin, uint8_t bpin, bool com = COM_CATHODE) : _rpin(rpin), _gpin(gpin), _bpin(bpin), _anode(com) {
-        pinMode(rpin, OUTPUT);
-        pinMode(gpin, OUTPUT);
-        pinMode(bpin, OUTPUT);
         disable();
     }
 


### PR DESCRIPTION
Опытным путём было установлено, что скетч нормально работает и без вызовов pinMode() в конструкторе. Кроме того, вызовы pinMode() в конструкторе в некоторых экспериментах непредсказуемо влияли на дальнейшие вызовы digitalWrite() в отношении пинов _rpin, _gpin и _bpin (см. [предыдущий пулл реквест](https://github.com/GyverLibs/RGBLED/pull/1)). Это уже не слишком важно, поскольку в методе disable() теперь вместо digitalWrite() вызывается analogWrite(), но всё же заслуживает упоминания.

Поэтому по согласованию с мейнтейнером удалил вызовы pinMode() из конструктора.